### PR TITLE
add reset_walk_speed_on_join option to fix slow movement issue on upgrade

### DIFF
--- a/src/main/java/net/endkind/enderCarryOn/EnderCarryOn.java
+++ b/src/main/java/net/endkind/enderCarryOn/EnderCarryOn.java
@@ -1,6 +1,7 @@
 package net.endkind.enderCarryOn;
 
 import net.endkind.enderCarryOn.Listener.ChestListener;
+import net.endkind.enderCarryOn.Listener.OnPlayerJoinListener;
 import net.endkind.enderCarryOn.Listener.ResourcePackListener;
 import net.endkind.enderCore.platform.papermc.EnderPlugin;
 
@@ -9,6 +10,10 @@ public final class EnderCarryOn extends EnderPlugin {
     public void onPluginEnable() {
         registerListener(new ChestListener());
         registerListener(new ResourcePackListener(this));
+
+        if (getConfig().getBoolean("reset_walk_speed_on_join")) {
+            registerListener(new OnPlayerJoinListener());
+        }
     }
 
     @Override

--- a/src/main/java/net/endkind/enderCarryOn/Listener/OnPlayerJoinListener.java
+++ b/src/main/java/net/endkind/enderCarryOn/Listener/OnPlayerJoinListener.java
@@ -1,0 +1,12 @@
+package net.endkind.enderCarryOn.Listener;
+
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+
+public class OnPlayerJoinListener implements Listener {
+    @EventHandler
+    public void onPlayerJoin(PlayerJoinEvent event) {
+        event.getPlayer().setWalkSpeed(0.2f);
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,4 +1,4 @@
-version: 1
+version: 2
 
 prefix:
   name: 'EnderCarryOn'
@@ -9,3 +9,5 @@ resource_pack:
   use: true
   url: "https://github.com/Endkind/EnderCarryOn/releases/download/{tag}/resourcepack.zip"
   hash: "{hash_resourcepack}"  # A 40 character hexadecimal and lowercase SHA-1 digest of the resource pack file.
+
+reset_walk_speed_on_join: false  # Only required when upgrading from v0.0.1 to a higher version if players experience constant slow movement issues.


### PR DESCRIPTION
- Added new configuration option "reset_walk_speed_on_join: false" to reset the player's walk speed on join.
- Fixes an issue for players upgrading from v0.0.1 who may experience constant slow movement.